### PR TITLE
Prevent storybook build from running on all pull request activity

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -6,8 +6,8 @@ name: Build storybook artifact
 on:
   push:
     branches: ["actions", "main"]
-  pull_request:
-    branches: ["actions", "main"]
+#  pull_request:
+#    branches: ["actions", "main"]
 
 jobs:
   build:


### PR DESCRIPTION
- Website build happens on every commit to pr
- Only rebuild website on push to main