### PR TITLE
Change simple-table caption padding

### DIFF
--- a/src/components/SimpleTable.vue
+++ b/src/components/SimpleTable.vue
@@ -77,11 +77,13 @@ export default {
 }
 
 .wra-table > thead > tr > th:first-child,
+.wra-table > tbody > tr > th:first-child,
 .wra-table > tbody > tr > td:first-child {
   padding-left: 0;
 }
 
 .wra-table > thead > tr > th:last-child,
+.wra-table > tbody > tr > th:last-child,
 .wra-table > tbody > tr > td:last-child {
   padding-right: 0;
 }

--- a/src/components/SimpleTable.vue
+++ b/src/components/SimpleTable.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="wra-table-wrapper"
-    :class="{ 'wra-table-inherit': inheritBackground }"
+    class="wra-simple-table-wrapper"
+    :class="{ 'wra-simple-table-inherit': inheritBackground }"
   >
     <table
-      class="wra-table"
+      class="wra-simple-table"
       :class="{ 'left-align-headers': leftAlignHeaders }"
     >
-      <caption v-if="caption" class="wra-table-caption">
+      <caption v-if="caption" class="wra-simple-table-caption">
         <slot name="caption">
           <!-- Fallback prop -->
           {{ caption }}
@@ -40,7 +40,7 @@ export default {
 </script>
 
 <style>
-.wra-table-wrapper {
+.wra-simple-table-wrapper {
   padding: 0px 16px 16px 16px;
   background-color: #f1f1f1;
 }
@@ -49,7 +49,7 @@ export default {
   text-align: left;
 }
 
-.wra-table-caption {
+.wra-simple-table-caption {
   background-color: inherit;
   text-align: left;
   padding: 16px;
@@ -58,7 +58,7 @@ export default {
   font-size: 20px;
 }
 
-.wra-table {
+.wra-simple-table {
   width: 100%;
   line-height: 20px;
   color: #1f1f1f;
@@ -66,33 +66,33 @@ export default {
   table-layout: auto;
 }
 
-.wra-table-inherit {
+.wra-simple-table-inherit {
   background-color: inherit;
 }
 
-.wra-table > thead > tr > th {
+.wra-simple-table > thead > tr > th {
   border-bottom: 2px solid #666666;
 }
 
-.wra-table > tbody > tr > td,
-.wra-table > tbody > tr > th {
+.wra-simple-table > tbody > tr > td,
+.wra-simple-table > tbody > tr > th {
   border-bottom: 1px solid #666666;
 }
 
-.wra-table td,
-.wra-table th {
+.wra-simple-table td,
+.wra-simple-table th {
   padding: 16px;
 }
 
-.wra-table > thead > tr > th:first-child,
-.wra-table > tbody > tr > th:first-child,
-.wra-table > tbody > tr > td:first-child {
+.wra-simple-table > thead > tr > th:first-child,
+.wra-simple-table > tbody > tr > th:first-child,
+.wra-simple-table > tbody > tr > td:first-child {
   padding-left: 0;
 }
 
-.wra-table > thead > tr > th:last-child,
-.wra-table > tbody > tr > th:last-child,
-.wra-table > tbody > tr > td:last-child {
+.wra-simple-table > thead > tr > th:last-child,
+.wra-simple-table > tbody > tr > th:last-child,
+.wra-simple-table > tbody > tr > td:last-child {
   padding-right: 0;
 }
 </style>

--- a/src/components/SimpleTable.vue
+++ b/src/components/SimpleTable.vue
@@ -1,19 +1,23 @@
 <template>
-  <table
-    class="wra-table"
-    :class="{
-      'wra-table-inherit': inheritBackground,
-      'left-align-headers': leftAlignHeaders
-    }"
+  <div
+    class="wra-table-wrapper"
+    :class="{ 'wra-table-inherit': inheritBackground }"
   >
-    <caption v-if="caption" class="wra-table-caption">
-      <slot name="caption">
-        <!-- Fallback prop -->
-        {{ caption }}
+    <table
+      class="wra-table"
+      :class="{ 'left-align-headers': leftAlignHeaders }"
+    >
+      <caption v-if="caption" class="wra-table-caption">
+        <slot name="caption">
+          <!-- Fallback prop -->
+          {{ caption }}
+        </slot>
+      </caption>
+      <slot>
+        <!-- For table rows headers etc. -->
       </slot>
-    </caption>
-    <slot> </slot>
-  </table>
+    </table>
+  </div>
 </template>
 
 <script>
@@ -36,6 +40,11 @@ export default {
 </script>
 
 <style>
+.wra-table-wrapper {
+  padding: 0px 16px 16px 16px;
+  background-color: #f1f1f1;
+}
+
 .left-align-headers {
   text-align: left;
 }
@@ -44,6 +53,7 @@ export default {
   background-color: inherit;
   text-align: left;
   padding: 16px;
+  padding-left: 0px;
   font-weight: bold;
   font-size: 20px;
 }
@@ -51,10 +61,8 @@ export default {
 .wra-table {
   width: 100%;
   line-height: 20px;
-  background-color: #f1f1f1;
   color: #1f1f1f;
   border-spacing: 0;
-  padding: 0px 16px 16px 16px;
   table-layout: auto;
 }
 


### PR DESCRIPTION
# Captions

Captions ended up being shifted by `16px` to the right.

So, padding has been removed from most of table classes to reduce duplicating CSS padding for both caption and table. Instead a `div` is used with padding applied that surrounds everything.

# Table header padding

Table header padding was only applied in `<thead>`, added a rule to include padding in `<tbody>` too. 