### PR TITLE
Fix inputs after Maska update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "@wra-gov/vue-components",
-  "version": "0.12.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wra-gov/vue-components",
-      "version": "0.12.0",
+      "version": "0.17.0",
       "license": "OGL-UK-3.0",
+      "dependencies": {
+        "maska": "^3.0.2"
+      },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.6.17",
         "@storybook/addon-interactions": "^7.6.17",
@@ -27,7 +30,6 @@
       },
       "peerDependencies": {
         "@mdi/js": "^7.4.47",
-        "maska": "^2.1.11",
         "vue": "^3.3.4"
       }
     },
@@ -10413,10 +10415,10 @@
       }
     },
     "node_modules/maska": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/maska/-/maska-2.1.11.tgz",
-      "integrity": "sha512-IGqWjBnKxMYcVa06pb4mPfag9sJjnR2T15CdGfQ2llR3gajiSd4AxXCvNqHMEq9W3UBhjjTazgWumsP3sWrUSg==",
-      "peer": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/maska/-/maska-3.0.2.tgz",
+      "integrity": "sha512-onh3JCFrkUTFrrhhDpfQZGwQ830zeEUEVbuQDZpLzY/JXJ5QR+hQ6FJ7lcw1NikAixtpGXkxxC+teO5glT3Vyw==",
+      "license": "MIT"
     },
     "node_modules/mdast-util-definitions": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wra-gov/vue-components",
-  "version": "0.17.0",
+  "version": "0.17.2",
   "private": false,
   "type": "module",
   "homepage": "https://github.com/welsh-revenue-authority/component-library#readme",

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -5,12 +5,11 @@
       :id="id"
       type="text"
       :value="maskedValue"
-      :inputmode="inputmode || 'numeric'"
+      :inputmode="inputmode ?? 'numeric'"
       :placeholder="placeholder"
       :defaultValidation="defaultValidation"
       @input="convertToDate($event.target.value)"
-      v-maska
-      data-maska="##/##/####"
+      v-maska="'##/##/####'"
       data-maska-eager
     />
     <p v-if="showError && required != undefined">Invalid date</p>
@@ -24,17 +23,39 @@ export default {
   directives: { maska: vMaska },
   name: "wra-date-input",
   props: {
+    /**
+     * The value of the input field.
+     * @required
+     * @default ""
+     */
     modelValue: {
-      required: true
+      required: true,
+      default: ""
     },
+    /**
+     * The label for the input field.
+     * @type {string}
+     */
     label: {
       type: String
     },
+    /**
+     * The ID for the input field.
+     * @type {string}
+     * @required
+     * @default "dateInput"
+     */
     id: {
       required: true,
       default: "dateInput",
       type: String
     },
+    /**
+     * The input mode for the input field.
+     * @type {string}
+     * @default "numeric"
+     * @validator value {string} - The input mode must be "numeric".
+     */
     inputmode: {
       default: "numeric",
       type: String,
@@ -43,10 +64,21 @@ export default {
       }
     },
     required: {},
+    /**
+     * The placeholder text for the input field.
+     * @type {string}
+     * @default "DD/MM/YYYY"
+     *
+     */
     placeholder: {
       default: "DD/MM/YYYY",
       type: String
     },
+    /**
+     * Whether to use default validation for the input field.
+     * @type {boolean}
+     * @default false
+     */
     defaultValidation: {
       default: false
     }
@@ -59,6 +91,10 @@ export default {
     dateObjectValue: null
   }),
   watch: {
+    /**
+     * Watcher for modelValue prop.
+     * @param {string} newValue - The new value of the modelValue prop.
+     */
     modelValue(newValue) {
       //Required if parent changes the model value after rendering
       if (newValue != this.dateObjectValue) {
@@ -67,12 +103,16 @@ export default {
     }
   },
   methods: {
+    /**
+     * Swaps the day and month in a date string.
+     * @param {string} input - The input date string in DD/MM/YYYY format.
+     * @returns {string} - The date string with day and month swapped.
+     */
     swapMonthDay(input) {
       var value = input.split("/");
       let d = value[1] + "/" + value[0] + "/" + value[2];
       return d;
     },
-
     convertToDate(value) {
       this.maskedValue = value;
       if (value.length == 10) {
@@ -102,7 +142,7 @@ export default {
     },
     validate(dateInput) {
       // Bypass built in validation if defaultValidation = false
-      if (this.defaultValidation == false) {
+      if (this.defaultValidation === false) {
         return true;
       }
 
@@ -151,8 +191,15 @@ export default {
 
       return result;
     },
+    /**
+     * Sets the initial state of the component based on the modelValue prop.
+     */
     setInitialState() {
-      if (this.modelValue == null || this.modelValue == "") {
+      if (
+        typeof this.modelValue == undefined ||
+        this.modelValue == null ||
+        this.modelValue == ""
+      ) {
         this.convertToDate("");
         return;
       }

--- a/src/components/PriceInput.vue
+++ b/src/components/PriceInput.vue
@@ -23,21 +23,50 @@
 <script>
 import { vMaska } from "maska/vue";
 
+/**
+ * PriceInput component
+ *
+ * This component provides a masked price input field with optional prefix and suffix.
+ * It uses the `maska` directive to apply input masks.
+ */
 export default {
   directives: { maska: vMaska },
   name: "wra-price-input",
   props: {
+    /**
+     * The value of the input field.
+     * @type {string|number}
+     * @required
+     * @default ""
+     */
     modelValue: {
-      required: true
+      required: true,
+      default: ""
     },
+    /**
+     * The label for the input field.
+     * @type {string}
+     */
     label: {
       type: String
     },
+    /**
+     * The ID for the input field.
+     * @type {string}
+     * @required
+     * @default "priceInput"
+     */
     id: {
       type: String,
       required: true,
       default: "priceInput"
     },
+    /**
+     * The input mode for the input field.
+     * @type {string}
+     * @default "decimal"
+     * @validator value {string} - The input mode must be one of ["numeric", "decimal", "text"].
+     */
     inputmode: {
       default: "decimal",
       type: String,
@@ -45,15 +74,33 @@ export default {
         return ["numeric", "decimal", "text"].includes(value);
       }
     },
+    /**
+     * The placeholder text for the input field.
+     * @type {string}
+     * @default "0.00"
+     */
     placeholder: {
       default: "0.00",
       type: String
     },
+    /**
+     * Validation rules for the input field.
+     * @type {Array<Function>}
+     */
     rules: {},
+    /**
+     * The prefix text to display before the input field.
+     * @type {string}
+     * @default "£"
+     */
     prefix: {
       default: "£",
       type: String
     },
+    /**
+     * The suffix text to display after the input field.
+     * @type {string}
+     */
     suffix: {
       type: String
     }
@@ -89,9 +136,9 @@ export default {
         .toString()
         .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     },
-    "returnValue.masked"() {
-      this.$emit("update:modelValue", this.returnValue.masked);
-      this.validate(this.returnValue.masked);
+    returnValue() {
+      this.$emit("update:modelValue", this.returnValue);
+      this.validate(this.returnValue);
     }
   },
   methods: {
@@ -137,6 +184,7 @@ export default {
   mounted() {
     //Run validation rules when component first is rendered as v-model data might be valid/invalid
     this.maskedValue = this.modelValue;
+    this.$emit("update:modelValue", this.maskedValue);
     this.validate(this.modelValue);
   }
 };

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -4,12 +4,11 @@
     <input
       :id="id"
       :type="type"
-      v-maska
-      :data-maska="dataMaska"
+      v-maska="dataMaska"
       :dataMaskaTokens="dataMaskaTokens"
       :value="modelValue"
       @input="validate($event.target.value)"
-      :inputmode="inputmode || 'text'"
+      :inputmode="inputmode ?? 'text'"
       :placeholder="placeholder"
     />
     <p>{{ errorMessage }}</p>
@@ -23,17 +22,40 @@ export default {
   directives: { maska: vMaska },
   name: "wra-text-input",
   props: {
+    /**
+     * The value of the input field.
+     * @type {string|number}
+     * @required
+     * @default ""
+     */
     modelValue: {
-      required: true
+      required: true,
+      default: ""
     },
+    /**
+     * The label for the input field.
+     * @type {string}
+     */
     label: {
       type: String
     },
+    /**
+     * The ID for the input field.
+     * @type {string}
+     * @required
+     * @default "customInput"
+     */
     id: {
       type: String,
       required: true,
       default: "textInput"
     },
+    /**
+     * The input mode for the input field.
+     * @type {string}
+     * @default "numeric"
+     * @validator value {string} - The input mode must be one of ["none", "text", "tel", "url", "email", "numeric", "decimal", "search"].
+     */
     inputmode: {
       type: String,
       default: "text",
@@ -50,6 +72,12 @@ export default {
         ].includes(value);
       }
     },
+    /**
+     * The type of the input field.
+     * @type {string}
+     * @default "text"
+     * @validator value {string} - The type must be one of ["text", "none", "tel", "url", "email", "numeric", "decimal"].
+     */
     type: {
       type: String,
       default: "text",
@@ -59,9 +87,29 @@ export default {
         );
       }
     },
+    /**
+     * Validation rules for the input field.
+     * @type {Array<Function>}
+     */
     rules: {},
-    dataMaska: {},
-    dataMaskaTokens: {},
+    /**
+     * The mask pattern for the input field.
+     * @type {string}
+     */
+    dataMaska: {
+      type: String
+    },
+    /**
+     * Custom tokens for the mask.
+     * @type {string}
+     */
+    dataMaskaTokens: {
+      type: String
+    },
+    /**
+     * The placeholder text for the input field.
+     * @type {string}
+     */
     placeholder: {
       type: String
     }
@@ -73,6 +121,10 @@ export default {
     };
   },
   methods: {
+    /**
+     * Validates the input value based on the provided rules.
+     * @param {string|number} value - The input value to validate.
+     */
     validate(value) {
       this.$emit("update:modelValue", value);
       this.errorMessage = "";
@@ -108,6 +160,7 @@ export default {
   mounted() {
     //Run validation rules when component first is rendered as v-model data might be valid/invalid
     this.validate(this.modelValue);
+    this.$emit("update:modelValue", this.modelValue);
   },
   emits: ["update:modelValue", "valid"]
 };


### PR DESCRIPTION
Bug fixes:
- Maska update changed syntax order for masking, all components refactored to use it
- Added `undefined` type checking to all components
- Changed emit behaviour in some to support `maska` event that emits both masked and unmasked object when `emitMaskaDetails` prop is used
  - Should not cause any regressions as behaviour is locked behind a prop


Please merge #81 and #83 before this as this bumps version number