### PR TITLE
Pagination bug and style fixes

### DIFF
--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -95,7 +95,7 @@ export default {
       }
     },
     decPage() {
-      if (this.currentPage >= this.startIndex) {
+      if (this.currentPage >= this.startIndex + 1) {
         this.currentPage--;
         this.$emit("update:currentPage", this.currentPage);
       }
@@ -111,7 +111,7 @@ export default {
       });
     },
     onKeyLeft() {
-      if (this.currentPage > this.startIndex) {
+      if (this.currentPage > this.startIndex + 1) {
         this.changePage(this.currentPage - 1);
       }
     },

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -91,18 +91,18 @@ export default {
     incPage() {
       if (this.currentPage < this.totalPages) {
         this.currentPage++;
-        this.$emit("update:currentPage", this.currentPage);
+        this.$emit("update:modelValue", this.currentPage);
       }
     },
     decPage() {
       if (this.currentPage >= this.startIndex + 1) {
         this.currentPage--;
-        this.$emit("update:currentPage", this.currentPage);
+        this.$emit("update:modelValue", this.currentPage);
       }
     },
     changePage(page) {
       this.currentPage = page;
-      this.$emit("update:currentPage", this.currentPage);
+      this.$emit("update:modelValue", this.currentPage);
       this.$nextTick(() => {
         if (!this.$refs?.[page]?.[0]) {
           console.log("No ref found for page", page);
@@ -121,7 +121,7 @@ export default {
       }
     }
   },
-  emits: ["update:currentPage"],
+  emits: ["update:modelValue"],
   computed: {
     pageArray() {
       return Array.from(

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -202,7 +202,7 @@ export default {
   border: none;
   font-size: 18px;
   cursor: pointer;
-  width: 3rem;
+  min-width: 3rem;
   text-align: center;
 }
 


### PR DESCRIPTION
Fixes some styling issues:
- Move from width to min-width to account for numbers larger than 3 digits

Fix bug:
- Did not add 1 to range when going back so clicking worked below 1

Small convenience fix:
- Rename emits to `update:modelValue` so that `v-model` can be used instead of manually writing it all

Please merge this before this #81 and #82 please.