### PR TITLE
Add scoped slot breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -2,7 +2,7 @@
   <ul class="wra-breadcrumbs">
     <template v-for="(item, index) in items">
       <li class="wra-breadcrumbs-item">
-        <slot>
+        <slot v-bind="item">
           <a
             v-if="!item[itemDisabled]"
             :href="item[itemHref]"

--- a/src/stories/Breadcrumbs.stories.ts
+++ b/src/stories/Breadcrumbs.stories.ts
@@ -94,3 +94,39 @@ export const replaceContent: Story = {
     }
   }
 };
+
+export const customRouterLink: Story = {
+  args: {
+    items: [
+      { title: "Dashboard", to: { name: "dashboard" }, disabled: false },
+      { title: "Link 1", to: { name: "link1" }, disabled: false },
+      { title: "Link 2", to: { name: "link2" }, disabled: true }
+    ]
+  },
+  render: (args) => ({
+    components: { Breadcrumbs },
+    setup() {
+      return { args };
+    },
+    template: `
+      <Breadcrumbs v-bind="args">
+        <template #link="{ to, title, disabled }">
+          <RouterLink :to="to" :class="{ 'disabled-link': disabled }">{{ title }}</RouterLink>
+        </template>
+      </Breadcrumbs>
+    `
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<WraBreadcrumbs :items="items">
+  <template #link="{ to, title, disabled }">
+    <RouterLink :to="to" :class="{ 'disabled-link': disabled }">{{ title }}</RouterLink>
+  </template>
+</WraBreadcrumbs>
+        `
+      }
+    }
+  }
+};


### PR DESCRIPTION
Allow replacing the default anchor tag with a `RouterLink` whilst still being able to access the `item` variable from within the component.